### PR TITLE
Removes return value for void function

### DIFF
--- a/src/SparkFun_ADS1015_Arduino_Library.cpp
+++ b/src/SparkFun_ADS1015_Arduino_Library.cpp
@@ -348,7 +348,7 @@ uint16_t ADS1015::readRegister16(byte location)
 void ADS1015::setComparatorSingleEnded(uint8_t channel, int16_t threshold)
 {
 	if (channel > 3) {
-		return 0;
+		return;
 	}
 	
 	uint16_t config = 


### PR DESCRIPTION
Compiling for ESP 32 Thing + was complaining about void functions returning values, fixed